### PR TITLE
Add unit column and fix undefined numbers

### DIFF
--- a/data/drills.json
+++ b/data/drills.json
@@ -2,6 +2,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 1,
     "name": "九九",
     "file": "data/ku_ku.html",
     "ns": "multiplication_1to9_v6_",
@@ -10,6 +11,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 2,
     "name": "一の段の九九（ばら）",
     "file": "data/ku_ku_1.html",
     "ns": "multiplication1dan_v1_",
@@ -18,6 +20,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 3,
     "name": "二の段の九九（ばら）",
     "file": "data/ku_ku_2.html",
     "ns": "multiplication2dan_v1_",
@@ -26,6 +29,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 4,
     "name": "三の段の九九（ばら）",
     "file": "data/ku_ku_3.html",
     "ns": "multiplication3dan_v1_",
@@ -34,6 +38,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 5,
     "name": "四の段の九九（ばら）",
     "file": "data/ku_ku_4.html",
     "ns": "multiplication4dan_v1_",
@@ -42,6 +47,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 6,
     "name": "五の段の九九（ばら）",
     "file": "data/ku_ku_5.html",
     "ns": "multiplication5dan_v1_",
@@ -50,6 +56,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 7,
     "name": "六の段の九九（ばら）",
     "file": "data/ku_ku_6.html",
     "ns": "multiplication6dan_v1_",
@@ -58,6 +65,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 8,
     "name": "七の段の九九（ばら）",
     "file": "data/ku_ku_7.html",
     "ns": "multiplication7dan_v1_",
@@ -66,6 +74,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 9,
     "name": "八の段の九九（ばら）",
     "file": "data/ku_ku_8.html",
     "ns": "multiplication8dan_v1_",
@@ -74,6 +83,7 @@
   {
     "grade": "2",
     "category": "九九",
+    "unit": 10,
     "name": "九の段の九九（ばら）",
     "file": "data/ku_ku_9.html",
     "ns": "multiplication9dan_v1_",

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
     <thead>
       <tr>
         <th data-key="grade">学年</th>
+        <th data-key="unit">単元</th>
         <th data-key="no">No.</th>
         <th data-key="name">名前</th>
         <th data-key="status">ステータス</th>
@@ -99,7 +100,17 @@
           const hist = JSON.parse(localStorage.getItem(d.ns + 'history') || '[]');
           if (hist.length) { status = hist[0].status || status; dt = hist[0].datetime || dt; }
         } catch {}
-        return { grade: d.grade, no: d.no, name: d.name, file: d.file, status, dt, hs, clears };
+        return {
+          grade: d.grade,
+          unit: d.unit ?? '',
+          no: d.no ?? '',
+          name: d.name,
+          file: d.file,
+          status,
+          dt,
+          hs,
+          clears
+        };
       });
     }
 
@@ -110,8 +121,9 @@
       if (!sort.dir) return filtered;
       return filtered.sort((a, b) => {
         let cmp = 0;
-        switch (sort.key) {
-          case 'no': cmp = (+a.no || 0) - (+b.no || 0); break;
+          switch (sort.key) {
+            case 'unit': cmp = (+a.unit || 0) - (+b.unit || 0); break;
+            case 'no': cmp = (+a.no || 0) - (+b.no || 0); break;
           case 'hs': case 'clears': cmp = (+a[sort.key] || 0) - (+b[sort.key] || 0); break;
           case 'status': cmp = statusOrder[a.status] - statusOrder[b.status]; break;
           case 'dt': cmp = ((a.dt==='―'?0:new Date(a.dt).getTime()) - (b.dt==='―'?0:new Date(b.dt).getTime())); break;
@@ -135,9 +147,10 @@
       const rows = filterAndSort(buildList);
       rows.forEach(item => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `
-          <td>${item.grade}</td>
-          <td>${item.no}</td>
+          tr.innerHTML = `
+            <td>${item.grade}</td>
+            <td>${item.unit}</td>
+            <td>${item.no}</td>
           <td><a href="${item.file}" target="_blank">${item.name}</a></td>
           <td>${item.status}</td>
           <td>${item.dt}</td>


### PR DESCRIPTION
## Summary
- display a Unit column between grade and No.
- support the new `unit` value in JS sorting/rendering
- avoid undefined numbers in the table
- provide `unit` entries for each drill

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68445e806cb483238598de7175733c7f