### PR TITLE
Change descending sort background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       position: relative;
     }
     th.sorted-asc { background: #b2ebf2; }
-    th.sorted-desc { background: #80deea; }
+    th.sorted-desc { background: #ffe0b2; }
     th.no-sort { cursor: default; }
     tr:hover {
       background: #fafafa;


### PR DESCRIPTION
## Summary
- change `sorted-desc` heading background to light orange

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68446eb6b0188323847409022ed124a1