### PR TITLE
Fix drill text

### DIFF
--- a/data/ku_ku.html
+++ b/data/ku_ku.html
@@ -32,13 +32,13 @@
 </style>
 </head>
 <body>
-  <h1>さんすうドリル</h1>
+  <h1>けいさんドリル</h1>
   <h2>九九</h2>
 
   <div id="problems-wrapper"></div>
 
   <div class="button-area">
-    <button id="check-answers">さい点</button>
+    <button id="check-answers">採点</button>
     <button id="retry">もういちど</button>
   </div>
 
@@ -49,10 +49,10 @@
       <button id="reset-highscore">リセット</button>
     </div>
     <div id="clearCountArea">
-      クリアかいすう：<span id="clearCountValue">0</span>
+      クリア回数：<span id="clearCountValue">0</span>
     </div>
     <div id="history-area">
-      りれき（さいしん10けん）<br>
+      履歴（最新10件）<br>
       <ul id="history-list"></ul>
     </div>
   </div>

--- a/data/ku_ku_1.html
+++ b/data/ku_ku_1.html
@@ -3,7 +3,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>一のだん（ばら）</title>
+<title>一の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -31,18 +31,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>一のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
   // メタデータ定義

--- a/data/ku_ku_2.html
+++ b/data/ku_ku_2.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>二のだん（ばら）</title>
+<title>二の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>二のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
   // メタデータ定義

--- a/data/ku_ku_3.html
+++ b/data/ku_ku_3.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>三のだん（ばら）</title>
+<title>三の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>三のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
     // メタデータ定義

--- a/data/ku_ku_4.html
+++ b/data/ku_ku_4.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>四のだん（ばら）</title>
+<title>四の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>四のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
     // メタデータ定義

--- a/data/ku_ku_5.html
+++ b/data/ku_ku_5.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>五のだん（ばら）</title>
+<title>五の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>五のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
     // メタデータ定義

--- a/data/ku_ku_6.html
+++ b/data/ku_ku_6.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>六のだん（ばら）</title>
+<title>六の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>六のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
   // メタデータ定義

--- a/data/ku_ku_7.html
+++ b/data/ku_ku_7.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>七のだん（ばら）</title>
+<title>七の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>七のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
   // メタデータ定義

--- a/data/ku_ku_8.html
+++ b/data/ku_ku_8.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>八のだん（ばら）</title>
+<title>八の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>八のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
   // メタデータ定義

--- a/data/ku_ku_9.html
+++ b/data/ku_ku_9.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
-<title>九のだん（ばら）</title>
+<title>九の段の九九</title>
 <style>
  body{font-family:sans-serif;background:#b3ecff;margin:20px;color:#333;font-size:2rem;line-height:1.5;}
  h1,h2{text-align:center;margin:10px 0}
@@ -30,18 +30,18 @@
 </style>
 </head>
 <body>
- <h1>さんすうドリル</h1>
+ <h1>けいさんドリル</h1>
  <h2>九のだん（ばら）</h2>
  <div id="problems-wrapper"></div>
  <div class="button-area">
-   <button id="check-answers">さい点</button>
+   <button id="check-answers">採点</button>
    <button id="retry">もういちど</button>
  </div>
  <div id="result-area">
    <div id="result"></div>
    <div id="highScoreArea">ハイスコア：<span id="highScoreValue">0</span> <button id="reset-highscore">リセット</button></div>
-   <div id="clearCountArea">クリアかいすう：<span id="clearCountValue">0</span></div>
-   <div id="history-area">りれき（さいしん10けん）<br><ul id="history-list"></ul></div>
+   <div id="clearCountArea">クリア回数：<span id="clearCountValue">0</span></div>
+   <div id="history-area">履歴（最新10件）<br><ul id="history-list"></ul></div>
  </div>
 <script>
     // メタデータ定義


### PR DESCRIPTION
## Summary
- revert Japanese heading text in drills
- revert button, count and history labels
- revert drill titles

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845a72e6634832385fc416163071921