### PR TITLE
Fix display of drills by correcting JSON

### DIFF
--- a/data/drills.json
+++ b/data/drills.json
@@ -80,7 +80,7 @@
     "ns": "multiplication9dan_v1_",
     "no": 9
   },
-    {
+  {
     "grade": "2",
     "category": "九九",
     "unit": 1,
@@ -88,5 +88,5 @@
     "file": "data/ku_ku.html",
     "ns": "multiplication_1to9_v6_",
     "no": 10
-  },
+  }
 ]


### PR DESCRIPTION
## Summary
- fix trailing comma in `drills.json` which prevented parsing

## Testing
- `node -e "const fs=require('fs'); try{ const x=JSON.parse(fs.readFileSync('data/drills.json','utf8')); console.log('parsed length', x.length); }catch(e){ console.error('parse error:', e.message); }"`

------
https://chatgpt.com/codex/tasks/task_e_6845a9e694b88323bd9b792e60a95e25